### PR TITLE
feat: queryDSL 라이브러리 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -52,6 +52,12 @@ dependencies {
 	// test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	//QueryDsl
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/dwbh/backend/config/QueryDslConfig.java
+++ b/backend/src/main/java/com/dwbh/backend/config/QueryDslConfig.java
@@ -1,0 +1,16 @@
+package com.dwbh.backend.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+
+public class QueryDslConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}


### PR DESCRIPTION
## 📝 PR 설명
queryDSL 라이브러리 추가

### 📌 관련 이슈
- **해결할 이슈**: Closes #(이슈 번호)
> 위와 같이 `Closes`, `Fixes`, `Resolves` 키워드를 사용하여 PR이 병합되면 자동으로 해당 이슈가 닫히도록 설정할 수 있습니다.

### 변경 사항
- gradle.build 에 queryDSL 라이브러리 추가
- backend/config 에 QueryDslConfig 파일 추가

### 🔍 상세 설명
- JPA 검색 조회 라이브러리인 queryDsl을 사용하기 위한 세팅 추가


