### PR TITLE
feat: 채팅방번호에 해당하는 평가 조회 기능 구현

### DIFF
--- a/backend/src/main/java/com/dwbh/backend/config/QueryDslConfig.java
+++ b/backend/src/main/java/com/dwbh/backend/config/QueryDslConfig.java
@@ -4,7 +4,9 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
+@Configuration
 public class QueryDslConfig {
     @PersistenceContext
     private EntityManager entityManager;

--- a/backend/src/main/java/com/dwbh/backend/controller/evaluation/EvaluationController.java
+++ b/backend/src/main/java/com/dwbh/backend/controller/evaluation/EvaluationController.java
@@ -1,0 +1,30 @@
+package com.dwbh.backend.controller.evaluation;
+
+import com.dwbh.backend.dto.evaluation.EvaluationDTO;
+import com.dwbh.backend.dto.evaluation.EvaluationResponse;
+import com.dwbh.backend.service.evaluation.EvaluationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController(value = "evaluationController")
+@RequiredArgsConstructor    // final을 받은 필드의 생성자를 주입
+@RequestMapping("/api/v1")
+@Slf4j
+public class EvaluationController {
+
+    private final EvaluationService evaluationService;
+
+    // 평가 수정을 위한 조회
+    @GetMapping("/chat/{id}/evaluation")
+    public ResponseEntity<EvaluationResponse> readEvaluation(@PathVariable("id") Long chatId) {
+
+        EvaluationResponse response = evaluationService.readEvaluation(chatId);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/src/main/java/com/dwbh/backend/dto/evaluation/EvaluationDTO.java
+++ b/backend/src/main/java/com/dwbh/backend/dto/evaluation/EvaluationDTO.java
@@ -1,0 +1,27 @@
+package com.dwbh.backend.dto.evaluation;
+
+import com.dwbh.backend.entity.Chat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@ToString
+@Schema(description = "평가 DTO")
+public class EvaluationDTO {
+    private Long evaluationSeq;
+    private Chat chatSeq;
+    private Integer evaluationSatisfaction;
+    private Integer evaluationCommunication;
+    private Integer evaluationKindness;
+    private Double evaluationScore;
+}
+
+

--- a/backend/src/main/java/com/dwbh/backend/dto/evaluation/EvaluationResponse.java
+++ b/backend/src/main/java/com/dwbh/backend/dto/evaluation/EvaluationResponse.java
@@ -1,0 +1,12 @@
+package com.dwbh.backend.dto.evaluation;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "평가 응답 데이터")
+public class EvaluationResponse {
+    private EvaluationDTO evaluation;
+}

--- a/backend/src/main/java/com/dwbh/backend/entity/evaluation/Evaluation.java
+++ b/backend/src/main/java/com/dwbh/backend/entity/evaluation/Evaluation.java
@@ -1,0 +1,49 @@
+package com.dwbh.backend.entity.evaluation;
+
+import com.dwbh.backend.entity.Chat;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "tb_evaluation")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@EntityListeners(AuditingEntityListener.class)  // 엔티티 생성, 삭제 시점 체크를 위해 필요한 리스너
+public class Evaluation {
+
+    @Id
+    @Column(name = "evaluation_seq")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long evaluationSeq;
+
+    @ManyToOne
+    @JoinColumn(name = "chat_seq", nullable = false)
+    private Chat chat;
+
+    @Column(name = "evaluation_satisfaction")
+    private Integer evaluationSatisfaction;
+
+    @Column(name = "evaluation_communication")
+    private Integer evaluationCommunication;
+
+    @Column(name = "evaluation_kindness")
+    private Integer evaluationKindness;
+
+    @Column(name = "evaluation_score")
+    private Double evaluationScore;
+
+    @CreatedDate
+    @Column(name = "evaluation_reg_date")
+    private LocalDateTime evaluationRegDate;
+
+    @LastModifiedDate
+    @Column(name = "evaluation_mod_date", insertable = false)
+    private LocalDateTime evaluationModDate;
+}

--- a/backend/src/main/java/com/dwbh/backend/repository/evaluation/EvaluationCustomRepository.java
+++ b/backend/src/main/java/com/dwbh/backend/repository/evaluation/EvaluationCustomRepository.java
@@ -1,0 +1,8 @@
+package com.dwbh.backend.repository.evaluation;
+
+import com.dwbh.backend.entity.evaluation.Evaluation;
+
+public interface EvaluationCustomRepository {
+
+    Evaluation findByChatSeq(Long chatSeq);
+}

--- a/backend/src/main/java/com/dwbh/backend/repository/evaluation/EvaluationRepository.java
+++ b/backend/src/main/java/com/dwbh/backend/repository/evaluation/EvaluationRepository.java
@@ -1,0 +1,8 @@
+package com.dwbh.backend.repository.evaluation;
+
+import com.dwbh.backend.entity.evaluation.Evaluation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EvaluationRepository extends JpaRepository<Evaluation, Long>, EvaluationCustomRepository {
+
+}

--- a/backend/src/main/java/com/dwbh/backend/repository/evaluation/EvaluationRepositoryImpl.java
+++ b/backend/src/main/java/com/dwbh/backend/repository/evaluation/EvaluationRepositoryImpl.java
@@ -1,0 +1,25 @@
+package com.dwbh.backend.repository.evaluation;
+
+import com.dwbh.backend.entity.evaluation.Evaluation;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import static com.dwbh.backend.entity.QChat.chat;
+import static com.dwbh.backend.entity.evaluation.QEvaluation.evaluation;
+
+@Repository
+@RequiredArgsConstructor
+public class EvaluationRepositoryImpl implements EvaluationCustomRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Evaluation findByChatSeq(Long chatSeq) {
+            return jpaQueryFactory
+                    .selectFrom(evaluation)
+                    .join(evaluation.chat, chat)
+                    .where(chat.chatSeq.eq(chatSeq))
+                    .fetchOne();
+    }
+}

--- a/backend/src/main/java/com/dwbh/backend/service/evaluation/EvaluationService.java
+++ b/backend/src/main/java/com/dwbh/backend/service/evaluation/EvaluationService.java
@@ -1,0 +1,29 @@
+package com.dwbh.backend.service.evaluation;
+
+import com.dwbh.backend.dto.evaluation.EvaluationDTO;
+import com.dwbh.backend.dto.evaluation.EvaluationResponse;
+import com.dwbh.backend.entity.evaluation.Evaluation;
+import com.dwbh.backend.repository.evaluation.EvaluationRepository;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EvaluationService {
+
+    private final EvaluationRepository evaluationRepository;
+    private final ModelMapper modelMapper;
+
+    // 채팅방번호에 해당하는 평가 조회
+    public EvaluationResponse readEvaluation(Long chatId) {
+        Evaluation evaluation = evaluationRepository.findByChatSeq(chatId);
+
+        // 엔티티를 DTO 로 변환
+        EvaluationDTO evaluationDTO = modelMapper.map(evaluation, EvaluationDTO.class);
+
+        return EvaluationResponse.builder() // 이 클래스가 가지고 있는 필드값들이 메서드에 자동완성, 세팅을 여기서 함
+                .evaluation(evaluationDTO)
+                .build();
+    }
+}


### PR DESCRIPTION
## 📝 PR 설명
채팅방 번호에 해당하는 평가 조회 기능 구현

### 📌 관련 이슈
- **해결할 이슈**: Closes #15 
> 위와 같이 `Closes`, `Fixes`, `Resolves` 키워드를 사용하여 PR이 병합되면 자동으로 해당 이슈가 닫히도록 설정할 수 있습니다.

### 변경 사항
- querydslconfig 파일의 Configuration 어노테이션 누락 수정
- 평가 컨트롤러, 서비스, 레포지토리, 엔티티, DTO, Response 추가
- 평가 조회 기능 추가

### 🔍 상세 설명
- 평가 조회를 채팅방 번호를 이용하여 queryDSL 을 사용하여 레포지토리 클래스에 구현함
- DTO 에는 등록일, 수정일 제외
- 채팅방 엔티티와 chat_seq 로 ManytoOne 관계 설정

### ✅ 체크리스트
- [ ] 코드가 컴파일/빌드 됨
- [ ] 테스트가 통과함 (단위 테스트 및 통합 테스트 포함)
- [ ] 문서가 업데이트됨 (필요시)

### 📋 테스트 사항
- PostMan 으로 8089 포트에서 연결 시도 하였고, 정상적으로 결과 출력

### 📄 참고 사항
- 예외 처리나 서비스 테스트 코드는 평가 관련 기능 모두 구현 후 작성 예정
