### PR TITLE
Feat/#30 평가 테스트 작성

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -4,6 +4,7 @@
     <modules>
       <module fileurl="file://$PROJECT_DIR$/.idea/DWBH.iml" filepath="$PROJECT_DIR$/.idea/DWBH.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/backend.main.iml" filepath="$PROJECT_DIR$/.idea/modules/backend.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/com.dwbh.backend.main.iml" filepath="$PROJECT_DIR$/.idea/modules/com.dwbh.backend.main.iml" />
     </modules>
   </component>
 </project>

--- a/backend/src/main/java/com/dwbh/backend/controller/evaluation/EvaluationController.java
+++ b/backend/src/main/java/com/dwbh/backend/controller/evaluation/EvaluationController.java
@@ -3,12 +3,15 @@ package com.dwbh.backend.controller.evaluation;
 import com.dwbh.backend.dto.evaluation.EvaluationRequest;
 import com.dwbh.backend.dto.evaluation.EvaluationResponse;
 import com.dwbh.backend.service.evaluation.EvaluationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "평가 컨트롤러", description = "평가 조회/작성/수정/삭제")
 @RestController(value = "evaluationController")
 @RequiredArgsConstructor    // final을 받은 필드의 생성자를 주입
 @RequestMapping("/api/v1")
@@ -18,6 +21,7 @@ public class EvaluationController {
     private final EvaluationService evaluationService;
 
     // 평가 수정을 위한 조회
+    @Operation(summary = "평가 조회", description = "채팅방번호에 해당하는 평가를 조회한다.")
     @GetMapping("/chat/{chatSeq}/evaluation")
     public ResponseEntity<EvaluationResponse> readEvaluation(@PathVariable("chatSeq") Long chatSeq) {
 
@@ -27,6 +31,7 @@ public class EvaluationController {
     }
 
     // 평가 작성
+    @Operation(summary = "평가 작성", description = "작성되지 않은 평가를 작성한다.")
     @PostMapping("/evaluation")
     public ResponseEntity<String> createEvaluation(
             @RequestBody EvaluationRequest evaluationRequest
@@ -37,6 +42,7 @@ public class EvaluationController {
     }
 
     // 평가 수정
+    @Operation(summary = "평가 수정", description = "이미 작성된 평가를 수정한다.")
     @PutMapping("/evaluation/{evaluationSeq}")
     public ResponseEntity<String> updateEvaluation(
             @PathVariable Long evaluationSeq,
@@ -48,6 +54,7 @@ public class EvaluationController {
     }
 
     // 평가 삭제
+    @Operation(summary = "평가 삭제", description = "이미 작성된 평가를 삭제한다.")
     @DeleteMapping("/evaluation/{evaluationSeq}")
     public ResponseEntity<String> deleteEvaluation(
             @PathVariable Long evaluationSeq

--- a/backend/src/main/java/com/dwbh/backend/repository/evaluation/EvaluationRepositoryImpl.java
+++ b/backend/src/main/java/com/dwbh/backend/repository/evaluation/EvaluationRepositoryImpl.java
@@ -6,7 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import static com.dwbh.backend.entity.QChat.chat;
-import static com.dwbh.backend.entity.evaluation.QEvaluation.evaluation;
+import static com.dwbh.backend.entity.QEvaluation.evaluation;
 
 @Repository
 @RequiredArgsConstructor

--- a/backend/src/test/java/com/dwbh/backend/service/evaluation/EvaluationServiceTest.java
+++ b/backend/src/test/java/com/dwbh/backend/service/evaluation/EvaluationServiceTest.java
@@ -13,20 +13,6 @@ import org.springframework.test.context.TestPropertySource;
 import java.util.stream.Stream;
 
 @SpringBootTest
-@TestPropertySource(properties = {
-        "MYSQL_ROOT_PASSWORD=root",
-        "MYSQL_HOST=localhost",
-        "MYSQL_DATABASE=dwbh",
-        "MYSQL_USER=dwbh",
-        "MYSQL_PASSWORD=dwbh",
-        "MYSQL_PORT=3309",
-        "MONGO_HOST=localhost",
-        "MONGO_PORT=27017",
-        "MONGO_AUTHENTICATION_DATABASE=admin",
-        "MONGO_INITDB_ROOT_USERNAME=dwbh",
-        "MONGO_INITDB_ROOT_PASSWORD=dwbh",
-        "MONGO_DATABASE=dwbh",
-})
 class EvaluationServiceTest {
 
     @Autowired

--- a/backend/src/test/java/com/dwbh/backend/service/evaluation/EvaluationServiceTest.java
+++ b/backend/src/test/java/com/dwbh/backend/service/evaluation/EvaluationServiceTest.java
@@ -1,0 +1,112 @@
+package com.dwbh.backend.service.evaluation;
+
+import com.dwbh.backend.dto.evaluation.EvaluationRequest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.stream.Stream;
+
+@SpringBootTest
+@TestPropertySource(properties = {
+        "MYSQL_ROOT_PASSWORD=root",
+        "MYSQL_HOST=localhost",
+        "MYSQL_DATABASE=dwbh",
+        "MYSQL_USER=dwbh",
+        "MYSQL_PASSWORD=dwbh",
+        "MYSQL_PORT=3309",
+        "MONGO_HOST=localhost",
+        "MONGO_PORT=27017",
+        "MONGO_AUTHENTICATION_DATABASE=admin",
+        "MONGO_INITDB_ROOT_USERNAME=dwbh",
+        "MONGO_INITDB_ROOT_PASSWORD=dwbh",
+        "MONGO_DATABASE=dwbh",
+})
+class EvaluationServiceTest {
+
+    @Autowired
+    private EvaluationService evaluationService;
+
+    private static Stream<Arguments> createEvaluationArguments() {
+        return Stream.of(
+                Arguments.of(
+                    3L,
+                        1,
+                        4,
+                        5
+                )
+        );
+    }
+
+    private static Stream<Arguments> updateEvaluationArguments() {
+        return Stream.of(
+                Arguments.of(
+                        6L,
+                        3L,
+                        5,
+                        5,
+                        5
+                )
+        );
+    }
+
+    /* 평가 조회 테스트 */
+    @Test
+    void testReadEvaluation() {
+        Assertions.assertDoesNotThrow(
+                () -> evaluationService.readEvaluation(3L)
+        );
+    }
+
+    /* 평가 작성 테스트 */
+    @ParameterizedTest
+    @MethodSource("createEvaluationArguments")
+    void testCreateEvaluation(
+            Long chatSeq, Integer evaluationSatisfaction, Integer evaluationCommunication, Integer evaluationKindness
+    ) {
+
+        EvaluationRequest evaluationRequest = new EvaluationRequest(
+                chatSeq,
+                evaluationSatisfaction,
+                evaluationCommunication,
+                evaluationKindness
+        );
+
+        Assertions.assertDoesNotThrow(
+                () -> evaluationService.createEvaluation(evaluationRequest)
+        );
+    }
+
+    /* 평가 수정 테스트 */
+    @ParameterizedTest
+    @MethodSource("updateEvaluationArguments")
+    void testUpdateEvaluation(
+            Long evaluationSeq,
+            Long chatSeq, Integer evaluationSatisfaction, Integer evaluationCommunication, Integer evaluationKindness
+    ) {
+
+        EvaluationRequest evaluationRequest = new EvaluationRequest(
+                chatSeq,
+                evaluationSatisfaction,
+                evaluationCommunication,
+                evaluationKindness
+        );
+
+        Assertions.assertDoesNotThrow(
+                () -> evaluationService.updateEvaluation(evaluationSeq, evaluationRequest)
+        );
+    }
+
+    /* 평가 삭제 테스트 */
+    @Test
+    void testDeleteEvaluation() {
+        Assertions.assertDoesNotThrow(
+                () -> evaluationService.deleteEvaluation(6L)
+        );
+    }
+}


### PR DESCRIPTION
## 📝 PR 설명
- 평가 crud 테스트 및 queryDSL 모듈 추가
- swagger 작성

### 📌 관련 이슈
- **해결할 이슈**: Closes #30

### 변경 사항
- Junit 테스트 코드 작성
- queryDSL 사용시 Q클래스를 사용시  model.xml 안에 모듈 의존성 추가됨
- swagger tag 작성

### 🔍 상세 설명
- junit 작성시 .env 파일의 위치가 backend 하위에 존재해야 인식합니다.
- junit 테스트 진행 시 db에 정확한 데이터 입력됨
- queryDSL 사용시 Q클래스를 사용시 자동적으로  model.xml 안에 모듈 의존성 추가됨
- 삭제할 시 Q클래스를 불러오지 못해 어쩔수없이 추가
- swagger tag를 작성하여 알아보기 쉽게 설정

### ✅ 체크리스트
- [x] 코드가 컴파일/빌드 됨
- [x] 테스트가 통과함 (단위 테스트 및 통합 테스트 포함)
- [x] 문서가 업데이트됨 (필요시)
