### PR TITLE
Feat/#53 댓글수정

### DIFF
--- a/backend/src/main/java/com/dwbh/backend/common/entity/Gender.java
+++ b/backend/src/main/java/com/dwbh/backend/common/entity/Gender.java
@@ -1,6 +1,6 @@
 package com.dwbh.backend.common.entity;
 
 public enum Gender {
-    MALE,
-    FEMALE
+    male,
+    female
 }

--- a/backend/src/main/java/com/dwbh/backend/common/util/FileUploadUtils.java
+++ b/backend/src/main/java/com/dwbh/backend/common/util/FileUploadUtils.java
@@ -69,6 +69,14 @@ public class FileUploadUtils {
                 case "jpeg":
                 case "png":
                 case "gif":
+                case "ai":
+                case "psd":
+                case "tiff":
+                case "tif":
+                case "svg":
+                case "bmp":
+                case "eps":
+                case "raw":
                     mimeType = "image/" + extension;
                     break;
                 case "mp4":
@@ -82,6 +90,14 @@ public class FileUploadUtils {
         }
 
         return mimeType;
+    }
+
+    /*
+     * 파일이 이미지인지 확인
+     */
+    public static boolean isImageFile(MultipartFile file) {
+        String mimeType = file.getContentType();
+        return mimeType != null && (mimeType.startsWith("image/"));
     }
 
 }

--- a/backend/src/main/java/com/dwbh/backend/common/util/FileUploadUtils.java
+++ b/backend/src/main/java/com/dwbh/backend/common/util/FileUploadUtils.java
@@ -30,6 +30,9 @@ public class FileUploadUtils {
 
             /* 파일 저장 */
             Path filePath = uploadPath.resolve(replaceFileName);
+//            System.out.println("filePath: " + filePath.getRoot());
+//            System.out.println("filePath: " + filePath.getParent());
+
             Files.copy(inputStream, filePath, StandardCopyOption.REPLACE_EXISTING);
 
             return replaceFileName;

--- a/backend/src/main/java/com/dwbh/backend/controller/offer/OfferController.java
+++ b/backend/src/main/java/com/dwbh/backend/controller/offer/OfferController.java
@@ -1,6 +1,6 @@
 package com.dwbh.backend.controller.offer;
 
-import com.dwbh.backend.dto.offer.CreateOfferRequest;
+import com.dwbh.backend.dto.offer.CreateOrUpdateOfferRequest;
 import com.dwbh.backend.dto.offer.OfferDTO;
 import com.dwbh.backend.service.offer.OfferService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -23,16 +23,30 @@ public class OfferController {
     private final OfferService offerService;
 
     // 댓글 등록
-    @PostMapping("/{postSeq}/comment")
+    @PostMapping("/{hireSeq}/comment")
     @Operation(summary = "게시글 댓글 등록", description = "게시글에 댓글을 등록한다.")
     public ResponseEntity<OfferDTO> createOffer(
-            @PathVariable Long postSeq,
-            @Valid @RequestPart CreateOfferRequest createOfferRequest,
+            @PathVariable Long hireSeq,
+            @Valid @RequestPart CreateOrUpdateOfferRequest request,
             @RequestPart(required = false) MultipartFile file) {
-        log.info("POST /api/v1/hire-post/{postSeq}/comment 댓글 등록 요청 - {}, {}, {}", postSeq, createOfferRequest, file);
+        log.info("POST /api/v1/hire-post/{hireSeq}/comment 댓글 등록 요청 - {}, {}, {}", hireSeq, request, file);
 
-        OfferDTO response = offerService.createOffer(postSeq, createOfferRequest, file);
+        OfferDTO response = offerService.createOffer(hireSeq, request, file);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    // 댓글 수정
+    @PutMapping("/{hireSeq}/comment/{offerSeq}")
+    @Operation(summary = "게시글 댓글 수정", description = "자신이 작성한 게시글의 댓글을 수정한다.")
+    public ResponseEntity<OfferDTO> updateOffer(
+            @PathVariable Long hireSeq,
+            @PathVariable Long offerSeq,
+            @Valid @RequestPart CreateOrUpdateOfferRequest request,
+            @RequestPart(required = false) MultipartFile file) {
+        log.info("PUT /api/v1/hire-post/{hireSeq}/comment/{offerSeq} 댓글 수정 요청 - {}, {}, {}, {}", hireSeq, offerSeq, request, file);
+
+        OfferDTO response = offerService.updateOffer(hireSeq, offerSeq, request, file);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
 }

--- a/backend/src/main/java/com/dwbh/backend/dto/offer/CreateOrUpdateOfferRequest.java
+++ b/backend/src/main/java/com/dwbh/backend/dto/offer/CreateOrUpdateOfferRequest.java
@@ -5,11 +5,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 
 @Getter
 @Setter
-@Schema(description = "댓글 작성 DTO")
-public class CreateOfferRequest {
+@ToString
+@Schema(description = "댓글 작성 및 수정 DTO")
+public class CreateOrUpdateOfferRequest {
 
     private long userSeq;   // 댓글 작성자
     @NotBlank(message = "댓글 내용은 필수입니다.")

--- a/backend/src/main/java/com/dwbh/backend/dto/offer/OfferDTO.java
+++ b/backend/src/main/java/com/dwbh/backend/dto/offer/OfferDTO.java
@@ -15,10 +15,13 @@ public class OfferDTO {
     private long offerSeq;  // 댓글 번호
     private long hireSeq;   // 게시글 번호
     private long userSeq;   // 댓글 작성자
+
     private String offerContent;    // 댓글 내용
     private YnType offerPrivateYn;  // 비밀 댓글 여부
+
     private LocalDateTime offerRegDate;     // 댓글 작성일
     private LocalDateTime offerModDate;     // 댓글 수정일
+    private LocalDateTime offerDelDate;     // 댓글 삭제일
 
     private UserSummaryDTO userSummary; // 회원정보(닉네임, 성별, 나이대, 사진)
 

--- a/backend/src/main/java/com/dwbh/backend/entity/CounselOffer.java
+++ b/backend/src/main/java/com/dwbh/backend/entity/CounselOffer.java
@@ -20,6 +20,7 @@ import java.time.LocalDateTime;
         @AttributeOverride(name = "modDate", column = @Column(name = "counsel_offer_mod_date"))
 })
 @SQLDelete(sql = "UPDATE tb_counsel_offer SET counsel_offer_del_date = NOW() WHERE counsel_offer_seq = ?")
+@Setter
 public class CounselOffer extends BaseDateEntity {
 
     @Id
@@ -27,17 +28,13 @@ public class CounselOffer extends BaseDateEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long offerSeq;
 
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "counselor_hire_seq", nullable = false)
-//    private CounselorHire hireSeq;
-    @Column(name = "counselor_hire_seq", nullable = false)
-    private Long hireSeq;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "counselor_hire_seq", nullable = false)
+    private CounselorHire hire;
 
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "user_seq", nullable = false)
-//    private User userSeq;
-    @Column(name = "user_seq", nullable = false)
-    private Long userSeq;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_seq", nullable = false)
+    private User user;
 
     @Column(name = "counsel_offer_content", nullable = false)
     private String offerContent;
@@ -50,7 +47,7 @@ public class CounselOffer extends BaseDateEntity {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime delDate;
 
-    @OneToOne(mappedBy = "counselOffer", cascade = {CascadeType.PERSIST, CascadeType.MERGE}, optional = true)   // 파일 선택, 작성,수정시
+    @OneToOne(mappedBy = "counselOffer", cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE}, orphanRemoval = true, optional = true)   // 파일 선택, 작성,수정시
     private CounselOfferFile offerFile;
 
     // 파일 첨부를 위한 메서드
@@ -58,20 +55,21 @@ public class CounselOffer extends BaseDateEntity {
         this.offerFile = offerFile;
     }
 
-    // 게시글 작성 시 userSeq를 Entity 에 담는 메서드
-//    public void putUserSeq(User userSeq) {
-//        this.userSeq = userSeq;
-//    }
-    public void putUserSeq(long userSeq) {
-        this.userSeq = userSeq;
+    // 댓글 작성 시 userSeq를 Entity 에 담는 메서드
+    public void putUserSeq(User userSeq) {
+        this.user = userSeq;
     }
 
-    // 게시글 작성 시 hireSeq Entity 에 담는 메서드
-//    public void putHireSeq(CounselorHire hireSeq) {
-//        this.hireSeq = hireSeq;
-//    }
-    public void putHireSeq(long hireSeq) {
-        this.hireSeq = hireSeq;
+    // 댓글 작성 시 hireSeq Entity 에 담는 메서드
+    public void putHireSeq(CounselorHire hireSeq) {
+        this.hire = hireSeq;
+    }
+
+    // 댓글 수정을 위한 메서드
+    public void updateContent(String content, YnType privateYn) {
+        this.offerContent = content;
+        this.offerPrivateYn = privateYn;
+        // 수정일 자동 등록(댓글 내용이나 비밀글 변경시)
     }
 
 

--- a/backend/src/main/java/com/dwbh/backend/entity/CounselorHire.java
+++ b/backend/src/main/java/com/dwbh/backend/entity/CounselorHire.java
@@ -33,7 +33,7 @@ public class CounselorHire extends BaseDateEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_seq", nullable = false)
-    private User userSeq;
+    private User user;
 
     @Column(name = "counselor_hire_title", nullable = false)
     private String hireTitle;
@@ -49,11 +49,11 @@ public class CounselorHire extends BaseDateEntity {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime delDate;
 
-    @OneToMany(mappedBy = "hireSeq", cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "hire", cascade = CascadeType.REMOVE)
     private List<CounselOffer> offers = new ArrayList<>();
 
     public void updateUser(User foundUser){
-        this.userSeq = foundUser;
+        this.user = foundUser;
     }
 
     public void updateCounselor(String counselorHireTitle, String counselorHireContent, String counselorHireCounselorGender) {

--- a/backend/src/main/java/com/dwbh/backend/entity/File.java
+++ b/backend/src/main/java/com/dwbh/backend/entity/File.java
@@ -1,6 +1,7 @@
 package com.dwbh.backend.entity;
 
 import com.dwbh.backend.common.entity.BaseDateEntity;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -40,6 +41,7 @@ public class File extends BaseDateEntity {
     @Column(name = "file_content_type", nullable = false)
     private String fileContentType;
 
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     @Column(name = "file_del_date")
     private LocalDateTime delDate;
 

--- a/backend/src/main/java/com/dwbh/backend/exception/ErrorCodeType.java
+++ b/backend/src/main/java/com/dwbh/backend/exception/ErrorCodeType.java
@@ -19,6 +19,7 @@ public enum ErrorCodeType {
 
     // user 관련 오류
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_ERROR_001", "사용자를 찾을 수 없습니다."),
+    INACTIVATE_USER(HttpStatus.NOT_FOUND, "USER_ERROR_002", "탈퇴된 회원입니다."),
 
     // chat 관련 오류
     CHAT_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT_ERROR_001", "채팅방을 찾을 수 없습니다."),
@@ -28,6 +29,11 @@ public enum ErrorCodeType {
     FILE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_ERROR_001", "파일 업로드에 실패했습니다"),
     FILE_DELETE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_ERROR_002", "파일 삭제에 실패했습니다"),
 
+    // 게시글 관련 오류
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "OFFER_ERROR_001", "댓글을 찾을 수 없습니다."),
+
+    // 댓글 관련 오류
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "OFFER_ERROR_001", "댓글을 찾을 수 없습니다."),
 
     // 알림 관련 오류
     NOTICE_ERROR(HttpStatus.BAD_REQUEST, "NOTICE_ERROR_001", "알림 발송에 실패하였습니다."),

--- a/backend/src/main/java/com/dwbh/backend/exception/ErrorCodeType.java
+++ b/backend/src/main/java/com/dwbh/backend/exception/ErrorCodeType.java
@@ -28,6 +28,7 @@ public enum ErrorCodeType {
     // 파일 관련 오류
     FILE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_ERROR_001", "파일 업로드에 실패했습니다"),
     FILE_DELETE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_ERROR_002", "파일 삭제에 실패했습니다"),
+    INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "FILE_ERROR_003", "첨부할 수 없는 파일형식입니다."),
 
     // 게시글 관련 오류
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "OFFER_ERROR_001", "댓글을 찾을 수 없습니다."),

--- a/backend/src/main/java/com/dwbh/backend/repository/FileRepository.java
+++ b/backend/src/main/java/com/dwbh/backend/repository/FileRepository.java
@@ -1,7 +1,0 @@
-package com.dwbh.backend.repository;
-
-import com.dwbh.backend.entity.File;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface FileRepository  extends JpaRepository<File, Long> {
-}

--- a/backend/src/main/java/com/dwbh/backend/repository/file/FileRepository.java
+++ b/backend/src/main/java/com/dwbh/backend/repository/file/FileRepository.java
@@ -1,0 +1,15 @@
+package com.dwbh.backend.repository.file;
+
+import com.dwbh.backend.entity.File;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+
+public interface FileRepository  extends JpaRepository<File, Long> {
+    @Modifying
+    @Query("UPDATE File f SET f.delDate = :delDate WHERE f.fileSeq = :fileSeq")
+    void softDeleteById(@Param("fileSeq") Long fileSeq, @Param("delDate") LocalDateTime delDate);
+}

--- a/backend/src/main/java/com/dwbh/backend/repository/offer/OfferRepository.java
+++ b/backend/src/main/java/com/dwbh/backend/repository/offer/OfferRepository.java
@@ -2,6 +2,10 @@ package com.dwbh.backend.repository.offer;
 
 import com.dwbh.backend.entity.CounselOffer;
 
+import java.util.Optional;
+
 public interface OfferRepository {
     CounselOffer save(CounselOffer offer);
+
+    Optional<CounselOffer> findById(Long offerSeq);
 }

--- a/backend/src/main/java/com/dwbh/backend/service/offer/OfferService.java
+++ b/backend/src/main/java/com/dwbh/backend/service/offer/OfferService.java
@@ -52,8 +52,13 @@ public class OfferService {
         offer.putHireSeq(hire);
 
         // 3. 파일이 포함된 경우 파일 먼저 저장
+        // 3-1. 이미지 파일 여부 확인
+        if (file != null && !FileUploadUtils.isImageFile(file)) {
+            throw new CustomException(ErrorCodeType.INVALID_FILE_TYPE);
+        }
+
+        // 3-2. 파일 저장
         if (file != null) {
-            // 파일 저장
             String savedFileName = FileUploadUtils.saveFile(UPLOAD_DIR, file);
 
             // MIME 타입 추출
@@ -114,7 +119,12 @@ public class OfferService {
         // 2. 댓글 내용 및 비밀 여부 수정
         offer.updateContent(request.getOfferContent(), request.getOfferPrivateYn());
 
-        // 3. 기존 파일 삭제 및 새 파일 추가
+        // 3-1. 이미지 파일 여부 확인
+        if (newFile != null && !FileUploadUtils.isImageFile(newFile)) {
+            throw new CustomException(ErrorCodeType.INVALID_FILE_TYPE);
+        }
+
+        // 3-2. 기존 파일 삭제 및 새 파일 추가
         if (newFile != null) {
             // 기존 파일이 있는 경우 소프트 딜리트 처리
             if (offer.getOfferFile() != null) {

--- a/backend/src/main/java/com/dwbh/backend/service/offer/OfferService.java
+++ b/backend/src/main/java/com/dwbh/backend/service/offer/OfferService.java
@@ -1,12 +1,14 @@
 package com.dwbh.backend.service.offer;
 
 import com.dwbh.backend.common.util.FileUploadUtils;
-import com.dwbh.backend.dto.offer.CreateOfferRequest;
+import com.dwbh.backend.dto.offer.CreateOrUpdateOfferRequest;
 import com.dwbh.backend.dto.offer.OfferDTO;
-import com.dwbh.backend.entity.CounselOffer;
-import com.dwbh.backend.entity.CounselOfferFile;
-import com.dwbh.backend.entity.File;
-import com.dwbh.backend.repository.FileRepository;
+import com.dwbh.backend.entity.*;
+import com.dwbh.backend.exception.CustomException;
+import com.dwbh.backend.exception.ErrorCodeType;
+import com.dwbh.backend.repository.UserRepository;
+import com.dwbh.backend.repository.counselor_hire.CounselorRepository;
+import com.dwbh.backend.repository.file.FileRepository;
 import com.dwbh.backend.repository.offer.OfferRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,6 +16,9 @@ import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 
 
 @Service
@@ -24,29 +29,29 @@ public class OfferService {
     private final OfferRepository offerRepository;
     private final FileRepository fileRepository;
     private final ModelMapper modelMapper;
-//    private final UserRepository userRepository;
-//    private final HireRepository hireRepository;
-    private static final String UPLOAD_DIR = "/uploads"; // 파일 저장 디렉토리
+    private final UserRepository userRepository;
+    private final CounselorRepository hireRepository;
+    private static final String UPLOAD_DIR = "uploads"; // 파일 저장 디렉토리
 
     @Transactional
-    public OfferDTO  createOffer(Long hireSeq, CreateOfferRequest createOfferRequest, MultipartFile file) {
+    public OfferDTO  createOffer(Long hireSeq, CreateOrUpdateOfferRequest request, MultipartFile file) {
         log.info("--------------댓글작성 서비스 진입----------------");
 
         // 1. 필요한 연관 관계 데이터 가져오기(추후 연관관계 기능 구현시 수정예정)
-//        User user = userRepository.findById(createOfferRequest.getUserSeq())
-//                .orElseThrow(() ->  new CustomException(ErrorCodeType.USER_NOT_FOUND));
-//        CounselorHire hire = hireRepository.findById(hireSeq())
-//                .orElseThrow(() -> new CustomException(ErrorCodeType.POST_NOT_FOUND));
+        User user = userRepository.findById(request.getUserSeq())
+                .orElseThrow(() ->  new CustomException(ErrorCodeType.USER_NOT_FOUND));
+        CounselorHire hire = hireRepository.findById(hireSeq)
+                .orElseThrow(() -> new CustomException(ErrorCodeType.POST_NOT_FOUND));
 
 
         // 2. DTO를 Entity로 매핑
-        CounselOffer offer = modelMapper.map(createOfferRequest, CounselOffer.class);
-        offer.putHireSeq(2L); // 임의로 설정
-        offer.putUserSeq(createOfferRequest.getUserSeq()); // 임의 설정
-//        offer.putUserSeq(user);
-//        offer.putHireSeq(hire);
+        CounselOffer offer = modelMapper.map(request, CounselOffer.class);
+//        offer.putHireSeq(2L); // 임의로 설정
+//        offer.putUserSeq(request.getUserSeq()); // 임의 설정
+        offer.putUserSeq(user);
+        offer.putHireSeq(hire);
 
-        // 2. 파일이 포함된 경우 파일 먼저 저장
+        // 3. 파일이 포함된 경우 파일 먼저 저장
         if (file != null) {
             // 파일 저장
             String savedFileName = FileUploadUtils.saveFile(UPLOAD_DIR, file);
@@ -72,4 +77,65 @@ public class OfferService {
         return response;
     }
 
+    @Transactional
+    public OfferDTO updateOffer(Long hireSeq, Long offerSeq, CreateOrUpdateOfferRequest request, MultipartFile newFile) {
+        log.info("--------------댓글수정 서비스 진입----------------");
+
+        // 1. 댓글 엔티티 조회(수정하려는 댓글 찾기)
+        User user = userRepository.findById(request.getUserSeq())
+                .orElseThrow(() ->  new CustomException(ErrorCodeType.USER_NOT_FOUND));
+        // 탈퇴된 회원인지 확인
+        if (!"activate".equals(user.getUserStatus())) {
+            // 탈퇴된 회원일 경우 수정 불가 예외 발생
+            throw new CustomException(ErrorCodeType.INACTIVATE_USER);
+        }
+
+        CounselorHire hire = hireRepository.findById(hireSeq)
+                .orElseThrow(() -> new CustomException(ErrorCodeType.POST_NOT_FOUND));
+
+        CounselOffer offer = offerRepository.findById(offerSeq)
+                .orElseThrow(() -> new CustomException(ErrorCodeType.COMMENT_NOT_FOUND));
+        // 수정 권한 검증(시큐리티 구현 후 추가 예정)
+//        if (!CustomUserUtils.getCurrentUserSeq().equals(offer.getUserSeq())) {
+//            throw new CustomException(ErrorCodeType.SECURITY_ACCESS_ERROR);
+//        }
+        long requestUserSeq  = request.getUserSeq();
+        log.info("-----------request의 userSeq: {}", requestUserSeq);
+        log.info("-----------db 저장 userSeq: {}", offer.getUser().getUserSeq());
+        if (requestUserSeq != offer.getUser().getUserSeq()) {
+            throw new CustomException(ErrorCodeType.SECURITY_ACCESS_ERROR);
+        }
+
+        // 이미 삭제된 게시글의 댓글이거나 이미 삭제된 댓글의 경우
+        if((offer.getDelDate() != null) || (offer.getHire().getDelDate() != null)) {
+            throw new CustomException(ErrorCodeType.COMMENT_NOT_FOUND);
+        }
+
+        // 2. 댓글 내용 및 비밀 여부 수정
+        offer.updateContent(request.getOfferContent(), request.getOfferPrivateYn());
+
+        // 3. 기존 파일 삭제 및 새 파일 추가
+        if (newFile != null) {
+            // 기존 파일이 있는 경우 소프트 딜리트 처리
+            if (offer.getOfferFile() != null) {
+                fileRepository.softDeleteById(offer.getOfferFile().getFile().getFileSeq(),  LocalDateTime.now(ZoneId.of("Asia/Seoul")));
+                // 관계를 끊어주기 위해 offerFile을 null로 설정
+                offer.inputOfferFile(null);
+            }
+
+            // 새 파일 저장
+            String savedFileName = FileUploadUtils.saveFile(UPLOAD_DIR, newFile);
+            String mimeType = FileUploadUtils.getMimeType(newFile);
+            File fileEntity = new File(savedFileName, mimeType, UPLOAD_DIR + "/" + savedFileName, newFile.getContentType());
+            fileEntity = fileRepository.save(fileEntity);
+
+            // 새 파일을 CounselOfferFile 엔티티에 생성
+            CounselOfferFile offerFile = new CounselOfferFile(fileEntity, offer);
+            offer.inputOfferFile(offerFile);
+
+        }
+
+        // 4. 엔티티를 DTO로 변환하여 반환
+        return modelMapper.map(offer, OfferDTO.class);
+    }
 }

--- a/backend/src/main/resources/dummy_data.sql
+++ b/backend/src/main/resources/dummy_data.sql
@@ -2,7 +2,8 @@
 INSERT INTO tb_user (user_email, user_password, user_nickname, user_gender, user_birthday, user_mbti, user_status, user_temperature)
 VALUES
     ('test1@example.com', 'password1', 'user1', 'male', '1990-01-01', 'INTJ', 'activate', 36.5),
-    ('test2@example.com', 'password2', 'user2', 'female', '1992-02-02', 'ENFP', 'activate', 36.8);
+    ('test2@example.com', 'password2', 'user2', 'female', '1992-02-02', 'ENFP', 'activate', 36.8),
+    ('test3@example.com', 'password3', 'user3', 'male', '1999-09-09', 'ENTP', 'activate', 36.50);
 
 -- tb_counselor_hire 테이블 더미 데이터
 INSERT INTO tb_counselor_hire (user_seq, counselor_hire_title, counselor_hire_content, counselor_hire_counselor_gender)


### PR DESCRIPTION
## 📝 PR 설명
댓글 수정 및 파일 첨부 수정
댓글/게시글/회원의 연관관계 추가

### 📌 관련 이슈
- **해결할 이슈**: Closes #53 

### 변경 사항
- 핵심 변경 내용: 댓글 수정 기능 구현 및 수정 시 파일 첨부/수정/삭제 기능 추가
- 주요 변경 파일 및 모듈:
- OfferController.java - 댓글 수정 API 추가
- OfferService.java - 댓글 수정 로직 구현 및 파일 삭제 후 재저장 처리 추가
- FileRepository.java - 파일 삭제시간 추가
- ErrorCode 추가
- 기타 DTO 및 엔티티 클래스 변경 및 추가

### 🔍 상세 설명
- 댓글 수정 기능 외에도 파일 삭제 후 재저장이 추가되어 파일 변경 시 새로 저장됨.
- OfferController.java: 댓글을 수정할 수 있는 API(POST /api/v1/hire-post/{hireSeq}/comment/{offerSeq})를 추가함. 댓글 작성 시 파일 첨부가 가능하도록 MultipartFile로 받음, 댓글 작성의 api 주소의 postSeq를 hireSeq로 수정(엔티티명을 따라 명확하게 하기위해)
- OfferService.java: 파일 삭제 및 저장 로직을 포함한 댓글 수정 로직을 구현. 파일이 포함된 경우, FileUploadUtils를 통해 파일을 서버에 저장하고, FileRepository를 통해 파일 정보를 DB에 저장
- FileRepository.java: 파일의 soft delete를 위한 메서드를 추가함.
- Gender.java: db의 저장 정보에 맞게 enum 타입을 소문자로 수정
- CreateOrUpdateOfferRequest.java: 작성 및 수정에서 같이 사용하기 위해 클래스명 수정
- OfferDTO: 엔티티와 맞추기 위해 모든 필드 작성(댓글 삭제일 추가)
- CounselOffer.java, CounselorHire.java:  연관관계 매핑을 위한 엔티티 변경
- dummy_data.sql: 회원 더미데이터 1개 추


### 🖥️ 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/75e40f2a-d83c-4337-af9f-4b1bfe1ecc05)
![image](https://github.com/user-attachments/assets/6ae22ea3-a3d9-4a27-ac27-b2c274dfbb79)
![image](https://github.com/user-attachments/assets/b8764d13-e887-493e-a8b8-d3c43e0bd819)


### 📄 참고 사항

파일에 사진만 올라가도록 수정했습니다.

파일 업로드 장소를 프로젝트 내의 upload 폴더로 변경하였습니다.
