### PR TITLE
feat: 게시글 리스트 페이징 처리

### DIFF
--- a/backend/src/main/java/com/dwbh/backend/repository/counselor_hire/CounselorRepositoryImpl.java
+++ b/backend/src/main/java/com/dwbh/backend/repository/counselor_hire/CounselorRepositoryImpl.java
@@ -130,12 +130,11 @@ public class CounselorRepositoryImpl implements CounselorCustomRepository {
                         genderEq(request.getSearchGender()),
                         typeSeqEq(request.getSearchTypeSeq()),
                         titleLike(request.getSearchTitle()))
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
+                .orderBy(counselorHire.regDate.desc())
                 .fetchResults();
 
         List<CounselorDTO> counselorList = results.getResults();
-
+        log.info("counselorList.size() : {}", counselorList.size());
         // 그룹화 처리
         Map<Long, CounselorDTO> groupedMap = new HashMap<>();
 
@@ -172,6 +171,7 @@ public class CounselorRepositoryImpl implements CounselorCustomRepository {
         // 그룹화된 리스트로 변환
         List<CounselorDTO> groupedList = new ArrayList<>(groupedMap.values());
         log.info("groupedList : {}", groupedList);
+        log.info("groupedList.size() : {}", groupedList.size());
         return new PageImpl<>(groupedList, pageable, groupedList.size());
     }
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2225,6 +2225,12 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/jquery": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3025,6 +3031,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/summernote": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/summernote/-/summernote-0.9.1.tgz",
+      "integrity": "sha512-5Hfuey6+N0XIbk8ZpkGEVDmrkRVRHZWKBhw/072i9/TJLaWUKboB+KOyyd6AzDP2CQs1O6or4zRTU8HY30kt4w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=17.0.0"
       }
     },
     "node_modules/tapable": {

--- a/frontend/src/views/counsel/CounselListView.vue
+++ b/frontend/src/views/counsel/CounselListView.vue
@@ -7,6 +7,7 @@ import Pagination from "@/components/common/Pagination.vue";
 import router from "@/router/index.js";
 
 const counselHires = ref([]);
+const paginationCounselHires = ref([]);
 const counselTypes = ref([]);
 const counselAgeRanges = ref([]);
 const hopeAgeSeq = ref(0);
@@ -33,11 +34,22 @@ const fetchCounselHires = async () => {
 
     counselHires.value = response.data.counselorList.content;
     totalCount.value = counselHires.value.length;
+    console.log(totalCount.value);
     counselTypes.value = response.data.counselorTypeList;
     counselAgeRanges.value = response.data.counselorAgeList;
+
+    paginate();
   } catch (error) {
     console.error('게시판 목록을 가져오는 중 오류 발생', error);
   }
+};
+
+// 현재 페이지에 따라 데이터 나누기
+const paginate = () => {
+  const start = (currentPage.value - 1) * pageSize.value;
+  const end = start + pageSize.value;
+  console.log(start, end);
+  paginationCounselHires.value = counselHires.value.slice(start, end);
 };
 
 const receivePagination = (page) => {
@@ -120,8 +132,8 @@ onMounted(() => {
             </tr>
             </thead>
             <tbody>
-            <tr v-for="(counselHire, index) in counselHires" :key="index">
-              <td>{{ index + 1 }}</td>
+            <tr v-for="(counselHire, index) in paginationCounselHires" :key="index">
+              <td>{{ index + 1 + (currentPage - 1) * pageSize }}</td>
               <td style="cursor:pointer;" @click="goCounselHireDetail(counselHire.hireSeq)">{{ counselHire.hireTitle }}</td>
               <td>{{ counselHire.userNickname }}</td>
               <td>{{ counselHire.hireGender === "male" ? "남성" : "여성" }}</td>


### PR DESCRIPTION
## 📝 PR 설명
게시글 리스트 페이징 처리

### 📌 관련 이슈
- **해결할 이슈**: Closes #114
> 위와 같이 `Closes`, `Fixes`, `Resolves` 키워드를 사용하여 PR이 병합되면 자동으로 해당 이슈가 닫히도록 설정할 수 있습니다.

### 변경 사항
- **핵심 변경 내용**: 백엔드 페이징 처리 -> 프론트 페이징 처리로 변경
- **주요 변경 파일 및 모듈**: CounselListView.vue, CounselRepositoryImpl

### 🔍 상세 설명
- **구현 내용**: 백엔드 페이징 처리 -> 프론트 페이징 처리로 변경
- **코드 영향 범위**: 이 변경이 다른 기능에 미칠 수 있는 영향을 설명합니다.

### ✅ 체크리스트
- [ ] 코드가 컴파일/빌드 됨
- [ ] 테스트가 통과함 (단위 테스트 및 통합 테스트 포함)
- [ ] 문서가 업데이트됨 (필요시)

### 📋 테스트 사항
- **테스트 추가 여부**: 새로운 테스트가 추가되었는지, 기존 테스트가 수정되었는지 여부
- **테스트 환경**: 테스트가 수행된 환경 (예: 브라우저, Node 버전, 운영체제)

### 🖥️ 스크린샷 (선택)
변경 사항을 설명하는 데 도움이 될 수 있는 스크린샷을 포함합니다.

### 📄 참고 사항
추가로 참고할 사항이나, 리뷰어가 알아야 할 특별한 내용이 있다면 작성해주세요.
