### PR TITLE
feat: 로그인 회원가입 기능 구현

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -5,6 +5,7 @@
       <module fileurl="file://$PROJECT_DIR$/.idea/DWBH.iml" filepath="$PROJECT_DIR$/.idea/DWBH.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/DWBH.backend.main.iml" filepath="$PROJECT_DIR$/.idea/modules/DWBH.backend.main.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/backend.main.iml" filepath="$PROJECT_DIR$/.idea/modules/backend.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/com.dwbh.backend.main.iml" filepath="$PROJECT_DIR$/.idea/modules/com.dwbh.backend.main.iml" />
     </modules>
   </component>
 </project>

--- a/backend/src/main/java/com/dwbh/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/dwbh/backend/config/SecurityConfig.java
@@ -99,6 +99,7 @@ public class SecurityConfig {
         config.addAllowedHeader("*"); // 모든 헤더 허용
         config.addAllowedMethod("*"); // 모든 HTTP 메소드 허용
         config.addExposedHeader("token"); // 서버측에서 보내는 헤더에 대한 허용 설정
+        config.addExposedHeader("verifyToken"); // 이메일 토큰 헤더 허용 설정
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", config);

--- a/backend/src/main/java/com/dwbh/backend/dto/CreateUserRequest.java
+++ b/backend/src/main/java/com/dwbh/backend/dto/CreateUserRequest.java
@@ -14,8 +14,8 @@ import java.time.LocalDate;
 public class CreateUserRequest {
     @NotBlank @Email
     private String userEmail;
-    // 10자 이상, 알파뱃 대소문자 포함, 특수문자(@$!%*?&_) 포함
-    @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&_])[A-Za-z\\d@$!%*?&_]{10,}$")
+    // 8자 이상, 알파뱃 대문자 또는 소문자 포함, 특수문자(@$!%*?&_) 포함
+    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[@$!%*?&_])[A-Za-z\\d@$!%*?&_]{8,}$")
     @NotBlank
     private String userPassword;
     @NotBlank

--- a/frontend/src/components/common/Header.vue
+++ b/frontend/src/components/common/Header.vue
@@ -16,6 +16,7 @@ const isDetailOpen = ref(false);
 const selectedChat = ref(null);
 
 const chat = ref(null);
+const userNickname = ref(null);
 const state = reactive({
   notificationList: [],
   isConfirmation: true,
@@ -57,6 +58,23 @@ const readNotification = async (notificationSeq) => {
   openChatDetail(chat.value);
 };
 
+// 유저 조회
+const readUser = async () => {
+  try {
+    const userSeq = authStore.userSeq;
+    const response = await axios.get(`http://localhost:8089/api/v1/user/${userSeq}`, {
+      headers: {
+        Authorization: `Bearer ${authStore.accessToken}`,
+      },
+    });
+    console.log(response.data);
+    userNickname.value = response.data.userNickname;
+    console.log(userNickname.value);
+  } catch (error) {
+    console.error("알림 가져오기 실패:", error);
+  }
+};
+
 // accessToken 이 있으면 로그인한 상태
 const isLoggedIn = computed(() => !!authStore.accessToken);
 const handleLogout = () => {
@@ -80,12 +98,11 @@ const handleClickOutside = (event) => {
   }
 };
 
-onMounted(() => {
+onMounted( async () => {
   document.addEventListener('click', handleClickOutside);
-  readNotificationList();
   if (isLoggedIn.value) {
-    // console.log(authStore.userSeq);  // seq 정보 사용
-    // readUserInfo(authStore.userSeq);  // 유저 정보 받아올 예정
+    await readNotificationList();
+    await readUser();
   }
 });
 

--- a/frontend/src/components/common/SideNotificationBar.vue
+++ b/frontend/src/components/common/SideNotificationBar.vue
@@ -34,8 +34,8 @@ const selectChat = (notificationSeq) => {
 <template>
   <div class="side-menu-bar">
     <div class="user-info">
-      <!--      <h3>{{ userInfo?.userName}} 님</h3>-->
-      <!--      <p>{{ userInfo?.userEmail}}</p>-->
+<!--      <h3>{{ user.userNickname }} 님</h3>-->
+      <h3>{{ authStore.userEmail }}</h3>
     </div>
 
     <hr class="menu-divider"/>
@@ -112,7 +112,7 @@ a {
 
 .menu-divider {
   border: none;
-  border-top: 1px solid #ddd; /* 옅은 회색 선 */
+  border-top: 5px solid #CCB997;
   margin: 10px 0; /* 메뉴 간 여백 */
 }
 

--- a/frontend/src/components/user/LoginForm.vue
+++ b/frontend/src/components/user/LoginForm.vue
@@ -1,0 +1,145 @@
+<script setup>
+import {ref} from 'vue';
+import InputBoxLong from "@/components/common/InputBoxLong.vue";
+import ButtonSmallColor from "@/components/common/ButtonSmallColor.vue";
+
+const email = ref('');
+const pwd = ref('');
+const errorMessage = ref('');
+
+const emit = defineEmits(['submit']);
+
+// 부모에게 errorMessage 받기
+const props = defineProps({
+  errorMessage: {
+    type: String,
+    default: ''
+  }
+});
+
+const handleLogin = () => {
+  if (!email.value || !pwd.value) {
+    errorMessage.value = '이메일과 비밀번호를 입력하세요.';
+  } else {
+    errorMessage.value = '';
+    emit('submit', email.value, pwd.value);
+  }
+};
+
+
+</script>
+
+<template>
+  <div class="login-container">
+
+    <div class="header">
+      <span>Login</span>
+    </div>
+
+    <div class="login-form">
+
+      <!-- 에러 메세지 표시 -->
+      <p v-if="errorMessage" class="error">{{ errorMessage }}</p>
+
+      <div class="field-group">
+        <!-- 이메일 필드 -->
+        <span>이메일</span>
+        <InputBoxLong
+            v-model="email"
+            placeholder="example.gmail.com"
+            type="email"
+        />
+      </div>
+
+      <!-- 비밀번호 필드 -->
+      <div class="field-group">
+        <span>비밀번호</span>
+        <InputBoxLong
+            v-model="pwd"
+            placeholder="영문, 특수문자를 모두 포함하여 8자리 이상"
+            type="password"
+        />
+      </div>
+
+      <!-- 로그인 버튼 -->
+      <ButtonSmallColor class="btn" @click="handleLogin">
+        로그인하기
+      </ButtonSmallColor>
+
+      <div class="actions">
+        <ButtonSmallColor class="btn" @click="handleLogin">
+          <RouterLink to="/users/passwords/emails">비밀번호 찾기</RouterLink>
+        </ButtonSmallColor>
+        <ButtonSmallColor class="btn" >
+          <RouterLink to="/register">회원가입</RouterLink>
+        </ButtonSmallColor>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.login-container {
+  align-items: center;
+  width: 80%;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  padding: 20px;
+  font-size: 30px;
+  font-weight: bold;
+}
+
+.login-form {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  padding: 20px;
+  border: 1px solid #ccc;
+  border-radius: 10px;
+  box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.1);
+  background-color: #fff;
+}
+
+
+.field-group {
+  width: 30%;
+  margin-bottom: 20px;
+}
+
+.form-group p {
+  text-align: left;
+  font-weight: bold;
+  font-size: 14px;
+}
+
+.btn {
+  margin: 20px;
+}
+
+h2 {
+  margin-bottom: 20px;
+}
+
+.actions {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  margin-top: 10px;
+}
+
+a {
+  color: black;
+  text-decoration: none;
+}
+
+.error {
+  color: #53D9C1;
+  font-weight: bold;
+}
+</style>

--- a/frontend/src/components/user/RegisterForm.vue
+++ b/frontend/src/components/user/RegisterForm.vue
@@ -14,8 +14,13 @@ const formData = ref({
 
 const confirmPassword = ref('');
 const errorMessage = ref('');
+const verificationCode = ref(''); // 이메일 인증 코드\
+const isClickNickName = ref(false);
 
-const emit = defineEmits(['submit', 'email', 'confirm']);
+// 비밀번호 일치 여부 확인
+const isPasswordMatch = computed(() => formData.value.userPassword === confirmPassword.value && formData.value.userPassword !== '');
+
+const emit = defineEmits(['submit', 'email', 'confirm', 'nickname']);
 
 // 부모에게 errorMessage 받기
 const props = defineProps({
@@ -23,16 +28,23 @@ const props = defineProps({
     type: String,
     default: ''
   },
+  sendEmail: {
+    type: Boolean,
+    default: false
+  },
   emailVerified: {
+    type: Boolean,
+    default: false
+  },
+  duplicationEmail: {
+    type: Boolean,
+    default: false
+  },
+  duplicationNickname: {
     type: Boolean,
     default: false
   }
 });
-
-
-const verificationCode = ref(''); // 이메일 인증 코드
-// 비밀번호 일치 여부 확인
-const isPasswordMatch = computed(() => formData.value.userPassword === confirmPassword.value);
 
 // formData가 변경될 때마다 메시지 초기화
 watch(formData, () => {
@@ -42,17 +54,7 @@ watch(formData, () => {
 // 이메일 인증 코드 전송
 const sendVerificationCode = async () => {
   if (formData.value.userEmail) {
-
-    const response = await axios.post('https://matzipapi.huichan.kr/user/api/v1/auth/mail-verification', {
-      userEmail: formData.value.userEmail,
-      userName: formData.value.userName,
-    });
-    console.log(response);
-
-    emit('email', {
-      userEmail: formData.value.userEmail,
-    })
-
+    emit('email', formData.value.userEmail);
   } else {
     errorMessage.value = '이메일을 모두 입력해 주세요.';
   }
@@ -61,20 +63,27 @@ const sendVerificationCode = async () => {
 // 이메일 인증 코드 확인
 const verifyEmailCode = async () => {
   if (verificationCode.value === '' || verificationCode.value == null) {
-    errorMessage.value = '인증코드를 입력해 주세요';
+    errorMessage.value = '인증 코드 입력해주세요';
     return;
   }
 
-  const response = await axios.post('https://matzipapi.huichan.kr/user/api/v1/auth/chkEmailCode', {
-    userEmail: formData.value.userEmail,
-    verificationCode: verificationCode.value,
-  });
-  console.log(response);
+  emit('confirm',
+      formData.value.userEmail,
+      verificationCode.value,
+  );
 
-  emit('confirm', {
-    userEmail: formData.value.userEmail,
-    verificationCode: verificationCode.value,
-  })
+};
+
+// 닉네임 중복 확인
+const checkNickname = async () => {
+  if (formData.value.userNickname === '' || formData.value.userNickname == null) {
+    errorMessage.value = '닉네임을 입력해주세요';
+    return;
+  }
+
+  emit('nickname', formData.value.userNickname);
+
+  isClickNickName.value = true;
 };
 
 // 성별 유효성 검사
@@ -86,30 +95,24 @@ const isGenderInvalid = computed(() => {
 
 // 폼 제출 핸들러
 const submitForm = () => {
+
   if (!props.emailVerified) {
     errorMessage.value = '이메일 인증이 필요합니다.';
     return;
   }
 
   // 비밀번호 패턴 검사
-  const passwordPattern = /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[!@#$%^&*.,?])[A-Za-z\d!@#$%^&*.,?]{10,}$/;
+  const passwordPattern = /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[!@#$%^&*.,?])[A-Za-z\d!@#$%^&*.,?]{8,}$/;
   if (!passwordPattern.test(formData.value.userPassword)) {
-    errorMessage.value = '비밀번호는 영문, 숫자, 특수문자를 포함한 10자 이상이어야 합니다.';
-    return;
-  }
-
-  // 비밀번호 확인
-  if (formData.value.userPassword !== confirmPassword) {
-    errorMessage.value = '비밀번호와 비밀번호 확인이 일치하지 않습니다.';
+    errorMessage.value = '비밀번호는 영문, 특수문자를 포함한 8자 이상이어야 합니다.';
     return;
   }
 
   // 성별 유효성 검사
-  if(isGenderInvalid){
+  if (isGenderInvalid.value) {
     errorMessage.value = '"male" 또는 "female"을 입력해 주세요.';
     return;
   }
-
 
   // 폼 제출 로직 (회원가입 처리)
   handleRegister();
@@ -137,145 +140,191 @@ const handleRegister = () => {
 </script>
 
 <template>
-  <div class="register-form">
-    <h2>JOIN</h2>
+  <div class="register-container">
 
-    <!-- 이메일 필드 -->
-    <div class="field-group">
-      <p>이메일</p>
-      <InputBoxLong
-          v-model="formData.userEmail"
-          placeholder="example@gmail.com"
-          type="email"
-          required
-      />
-      <ButtonSmallColor class="small-button" @click="sendVerificationCode">인증</ButtonSmallColor>
+    <div class="header">
+      <span>Join</span>
     </div>
 
-    <!-- 이메일 인증 필드 -->
-    <div class="field-group">
-      <p>이메일 인증</p>
-      <InputBoxLong
-          v-model="verificationCode"
-          placeholder="인증 코드를 입력하세요"
-          type="text"
-          required
-      />
-      <ButtonSmallColor class="small-button" @click="verifyEmailCode">확인</ButtonSmallColor>
-      <p v-if="props.emailVerified" class="message">이메일 인증이 완료되었습니다.</p>
+    <div class="register-form">
+      <!-- 오류 메시지 표시 영역 -->
+      <p v-if="errorMessage" class="error">{{ errorMessage }}</p>
+
+      <!-- 이메일 필드 -->
+      <div class="field-group">
+        <span>이메일</span>
+        <div>
+          <InputBoxLong
+              v-model="formData.userEmail"
+              placeholder="example@gmail.com"
+              type="email"
+              required
+          />
+          <span v-if="sendEmail">인증 메일이 발송되었습니다.</span>
+          <span v-if="duplicationEmail" class="error">이메일이 중복됩니다.</span>
+        </div>
+        <ButtonSmallColor class="small-button" @click="sendVerificationCode">발송</ButtonSmallColor>
+      </div>
+
+      <!-- 이메일 인증 필드 -->
+      <div class="field-group">
+        <span>이메일 인증</span>
+        <div>
+          <InputBoxLong
+              class="input-box"
+              v-model="verificationCode"
+              placeholder="인증 코드를 입력하세요"
+              type="text"
+              required
+          />
+          <span v-if="props.emailVerified" class="message">이메일 인증이 완료되었습니다.</span>
+        </div>
+        <ButtonSmallColor class="small-button" @click="verifyEmailCode">확인</ButtonSmallColor>
+      </div>
+
+      <div class="field-group">
+        <!-- 비밀번호 필드 -->
+        <span>비밀번호</span>
+        <InputBoxLong
+            class="input-box"
+            v-model="formData.userPassword"
+            placeholder="영문=, 특수문자를 모두 포함하여 8자리 이상"
+            type="password"
+            required
+        />
+      </div>
+
+      <div class="field-group">
+        <!-- 비밀번호 필드 -->
+        <span>비밀번호 확인</span>
+        <div>
+          <InputBoxLong
+              class="input-box"
+              v-model="confirmPassword"
+              placeholder="영문, 특수문자를 모두 포함하여 8자리 이상"
+              type="password"
+              required
+          />
+          <span v-if="!isPasswordMatch" class="error">비밀번호가 일치하지 않습니다.</span>
+          <span v-else class="message">비밀번호가 일치합니다.</span>
+        </div>
+      </div>
+
+      <div class="field-group">
+        <!-- 닉네임-->
+        <span>닉네임</span>
+        <div>
+          <InputBoxLong
+              class="input-box"
+              v-model="formData.userNickname"
+              placeholder="예) 길똥"
+              type="text"
+              required
+          />
+          <template v-if="isClickNickName">
+            <span v-if="duplicationNickname" class="error">닉네임이 중복됩니다.</span>
+            <span v-else class="message">사용가능한 닉네임입니다.</span>
+          </template>
+        </div>
+        <ButtonSmallColor class="small-button" @click="checkNickname">확인</ButtonSmallColor>
+      </div>
+
+
+      <div class="field-group">
+        <!-- 성별  -->
+        <span>성별</span>
+        <InputBoxLong
+            class="input-box"
+            v-model="formData.userGender"
+            placeholder="male or female"
+            type="text"
+            required
+        />
+      </div>
+
+
+      <div class="field-group">
+        <!-- 생년월일 필드 -->
+        <span>생년월일</span>
+        <InputBoxLong
+            class="input-box"
+            v-model="formData.userBirthday"
+            placeholder="ex) 2000-01-01"
+            type="date"
+            required
+        />
+      </div>
+
+      <div class="field-group">
+        <!-- MBTI 필드 -->
+        <span>MBTI</span>
+        <InputBoxLong
+            class="input-box"
+            v-model="formData.userMbti"
+            placeholder="MBTI를 입력해주세요"
+            type="text"
+            required
+        />
+      </div>
+
+      <!-- 회원가입 버튼 -->
+      <ButtonSmallColor class="btn" @click="submitForm">
+        가입하기
+      </ButtonSmallColor>
+
     </div>
-
-    <div class="field-group">
-      <!-- 비밀번호 필드 -->
-      <p>비밀번호</p>
-      <InputBoxLong
-          v-model="formData.userPassword"
-          placeholder="영문대소문자, 특수문자를 모두 포함하여 8자리 이상"
-          type="password"
-          required
-      />
-    </div>
-
-    <div class="field-group">
-      <!-- 비밀번호 필드 -->
-      <p>비밀번호 확인</p>
-      <InputBoxLong
-          v-model="confirmPassword"
-          placeholder="영문대소문자, 특수문자를 모두 포함하여 8자리 이상"
-          type="password"
-          required
-      />
-      <p v-if="!isPasswordMatch && confirmPassword">비밀번호가 일치하지 않습니다.</p>
-      <p v-else>비밀번호가 일치합니다.</p>
-    </div>
-
-
-    <div class="field-group">
-      <!-- 닉네임-->
-      <p>닉네임</p>
-      <InputBoxLong
-          v-model="formData.userNickname"
-          placeholder="예) 길똥"
-          type="text"
-          required
-      />
-    </div>
-
-
-    <div class="field-group">
-      <!-- 성별  -->
-      <p>성별</p>
-      <InputBoxLong
-          v-model="formData.userGender"
-          placeholder="male or female"
-          type="text"
-          required
-      />
-    </div>
-
-
-    <div class="field-group">
-      <!-- 생년월일 필드 -->
-      <p>생년월일</p>
-      <InputBoxLong
-          v-model="formData.userBirthday"
-          placeholder="ex) 2000-01-01"
-          type="date"
-          required
-      />
-    </div>
-
-    <div class="field-group">
-      <!-- MBTI 필드 -->
-      <p>MBTI</p>
-      <InputBoxLong
-          v-model="formData.userMbti"
-          placeholder="MBTI를 입력해주세요"
-          type="text"
-          required
-      />
-    </div>
-
-    <!-- 오류 메시지 표시 영역 -->
-    <p v-if="errorMessage" class="error-message">{{ errorMessage }}</p>
-
-    <!-- 회원가입 버튼 -->
-    <ButtonSmallColor class="btn" @click="submitForm">
-      가입하기
-    </ButtonSmallColor>
-
   </div>
+
 </template>
 
 <style scoped>
-.register-form {
+.register-container {
   align-items: center;
-  width: 500px;
+  width: 80%;
   margin: 0 auto;
   padding: 20px;
+}
+
+.register-form {
   display: flex;
   flex-direction: column;
+  align-items: center;
+  width: 100%;
+  padding: 20px;
   border: 1px solid #ccc;
   border-radius: 10px;
   box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.1);
   background-color: #fff;
 }
 
-.field-group {
-  width: 80%;
+.header {
+  display: flex;
+  align-items: center;
+  padding: 20px;
+  font-size: 30px;
+  font-weight: bold;
 }
 
-.field-group > * {
-  margin-bottom: 3px;
+.field-group {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  margin-bottom: 20px;
+  width: 70%;
+}
+
+.field-group > span {
+  width: 130px;
+}
+
+.input-box {
+  width: 500px;
 }
 
 .small-button {
   width: 60px;
   height: 30px;
-}
-
-.btn {
-  margin-top: 20px;
+  margin-left: 20px;
 }
 
 .error {

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -3,7 +3,7 @@ import { ref, onMounted } from 'vue';
 
 // 어디서든 사용할 수 있는 useAuthStore
 export const useAuthStore = defineStore('auth', () => {
-    const accessToken = ref('eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJra203aGpoQG5hdmVyLmNvbSIsInNlcSI6MywiYXV0aCI6W10sImV4cCI6MTczMTI1NTEyMX0.cfYfhWLqUWAD1_gYGP5v-K1p7k4oOx4Kb8y57eSUDd9iN6W4TMyzmM6maO3VDUJUl_StDTQzzt71Nsq6asilzA');
+    const accessToken = ref(null);
     const userRole = ref(null);
     const userEmail = ref(null);
     const userSeq = ref(null);
@@ -17,6 +17,7 @@ export const useAuthStore = defineStore('auth', () => {
             const payload = JSON.parse(atob(token.split('.')[1]));
             userRole.value = payload.auth;
             userSeq.value = payload.seq;
+            userEmail.value = payload.sub;
         }
     });
 
@@ -43,12 +44,14 @@ export const useAuthStore = defineStore('auth', () => {
         const payload = JSON.parse(atob(token.split('.')[1]));
         userRole.value = payload.auth;
         userSeq.value = payload.seq;  // seq 정보 추출해서 저장
+        userEmail.value = payload.sub;
     }
 
     function logout() {
         accessToken.value = null;
         userRole.value = null;
         userSeq.value = null;
+        userEmail.value = null;
         localStorage.removeItem('accessToken');
     }
 

--- a/frontend/src/views/evaluation/EvaluationView.vue
+++ b/frontend/src/views/evaluation/EvaluationView.vue
@@ -268,7 +268,7 @@ onMounted(async () => {
   align-items: center;
   margin-top: 10px;
   padding: 20px;
-  font-size: 20px;
+  font-size: 30px;
   font-weight: bold;
 }
 

--- a/frontend/src/views/user/LoginView.vue
+++ b/frontend/src/views/user/LoginView.vue
@@ -1,11 +1,58 @@
 <script setup>
+import {useRouter} from "vue-router";
+import {ref} from "vue";
+import axios from 'axios';
+import {useAuthStore} from "@/stores/auth.js";
+import LoginForm from "@/components/user/LoginForm.vue";
+
+const router = useRouter();
+const errorMessage = ref('');
+
+const authStore = useAuthStore();
+
+const handleLoginSubmit = async (email, password) => {
+  try {
+    console.log('handleLoginSubmit 실행');
+
+    const response = await axios.post('http://localhost:8089/api/v1/login', {
+      email: email,
+      password: password
+    },{
+      withCredentials: true
+    });
+
+    if (response.status === 200) {
+      // 헤더에서 토큰 추출
+      authStore.login(response.headers.token);
+      console.log('response.headers.token:', response.headers.token);
+      console.log('authStore.login 실행');
+
+      router.push('/'); // 로그인 성공 시 홈 화면으로 이동
+
+    }
+  } catch (error) {
+    // 서버에서 전송된 에러 메세지 추출
+    if (error.response.data.message) {
+      alert(`로그인 정보가 올바르지 않습니다.`);
+      location.reload();  // 새로고침
+    } else {
+      alert(`로그인 정보가 올바르지 않습니다.`);
+    }
+  }
+};
 
 </script>
 
 <template>
-  Login
+  <div class="login-view">
+    <LoginForm @submit="handleLoginSubmit" :errorMessage="errorMessage"/>
+  </div>
 </template>
 
 <style scoped>
 
+.login-view {
+  display: flex;
+  align-items: center;
+}
 </style>

--- a/frontend/src/views/user/RegisterView.vue
+++ b/frontend/src/views/user/RegisterView.vue
@@ -10,36 +10,142 @@ const LoadingState = ref(false);
 const authStore = useAuthStore();
 
 const errorMessage = ref('');
+const sendEmail = ref(false);
+const duplicationEmail = ref(false);
+const duplicationNickname = ref(false);
+const emailVerified = ref(false);
+const emailToken = ref(null);
+
+// 이메일 중복 체크
+const checkDuplicationEmail = async (email) => {
+  try {
+    if (email) {
+      const response = await axios.get(`http://localhost:8089/api/v1/user/email-check/${email}`, {});
+
+      // 이메일 중복일 경우
+      if (response.data === true) {
+        duplicationEmail.value = true;
+      }
+
+    }
+  } catch (error) {
+    // 서버에서 전송된 에러 메세지 추출
+    if (error.response.data.message) {
+      alert('정확한 이메일을 입력해주세요');
+    } else {
+      alert('정확한 이메일을 입력해주세요');
+    }
+  }
+};
+
+// 이메일 인증 코드 전송
+const sendVerificationCode = async (email) => {
+  try {
+    if (email) {
+      const response = await axios.post('http://localhost:8089/api/v1/user/email', {
+        email: email,
+      });
+      // 인증 코드 전송 성공
+      sendEmail.value = true;
+    }
+  } catch (error) {
+    // 서버에서 전송된 에러 메세지 추출
+    if (error.response.data.message) {
+      alert('정확한 이메일을 입력해주세요');
+    } else {
+      alert('정확한 이메일을 입력해주세요');
+    }
+  }
+};
+
+const checkEmail = async (email) => {
+  await checkDuplicationEmail(email);
+  if (!duplicationEmail.value)
+    await sendVerificationCode(email);
+}
+
+// 이메일 인증 코드 확인
+const verifyEmailCode = async (email, code) => {
+  try {
+    if (code === '' || code == null) {
+      errorMessage.value = '인증코드를 입력해 주세요';
+      return;
+    }
+
+    const response = await axios.get('http://localhost:8089/api/v1/user/email', {
+      params: {email, code},
+      withCredentials: true,  // 쿠키와 인증 정보를 포함하여 요청
+    });
+
+    // 응답에서 'verifyToken' 헤더를 추출
+    emailToken.value = response.headers['verifytoken'] || response.headers['verifyToken'];
+
+    // 이메일 인증 성공
+    emailVerified.value = true;
+  } catch (error) {
+    // 서버에서 전송된 에러 메세지 추출
+    if (error.response.data.message) {
+      alert('인증 실패');
+    } else {
+      alert('인증 실패');
+    }
+  }
+};
+
+// 닉네임 중복 체크
+const checkDuplicationNickname = async (nickname) => {
+  try {
+    if (nickname) {
+      const response = await axios.get(`http://localhost:8089/api/v1/user/nickname-check/${nickname}`, {});
+
+      // 이메일 중복일 경우
+      if (response.data === true) {
+        duplicationNickname.value = true;
+      }
+
+    }
+  } catch (error) {
+    // 서버에서 전송된 에러 메세지 추출
+    if (error.response.data.message) {
+      alert('정확한 닉네임을 입력해주세요');
+    } else {
+      alert('정확한 닉네임을 입력해주세요');
+    }
+  }
+};
 
 const handleRegisterSubmit = async (formData) => {
   // 백엔드 요청 보낼 때 로딩 시작
   LoadingState.value = true;
   try {
     // 백엔드 서버로 회원가입 데이터 전달
-    const response = await axios.post('http://localhost:8089/user', {
-      userEmail: formData.userEmail,
-      userNickname: formData.userNickname,
-      userPassword: formData.userPassword,
-      userBirthday: formData.userBirthday,
-      userGender: formData.userGender,
-      userMbti: formData.userMbti,
-    });
+    const response = await axios.post('http://localhost:8089/api/v1/user', {
+          userEmail: formData.userEmail,
+          userNickname: formData.userNickname,
+          userPassword: formData.userPassword,
+          userBirthday: formData.userBirthday,
+          userGender: formData.userGender,
+          userMbti: formData.userMbti,
+        }, {
+          headers: {
+            'Email-Verify-Header': emailToken.value,  // 헤더에 토큰 추가
+          },
+        }
+    );
 
     if (response.status === 201) {
       console.log('회원가입 성공');
       // 회원가입 성공 시 Pinia 스토어에 해당 이메일 저장
       authStore.registerEmail(formData.userEmail);
 
-      router.push('/users/emails/codes');
+      await router.push('/');
     }
-  } catch(error) {
-
+  } catch (error) {
     // 서버에서 전송된 에러 메세지 추출
     if (error.response.data.message) {
-      errorMessage.value = error.response.data.message;
+      alert(`회원가입에 실패했습니다. 다시 시도해주세요`);
     } else {
-      errorMessage.value = '다시 시도해주세요';
-      console.log('회원가입 실패: ', error);
+      alert(`회원가입에 실패했습니다. 다시 시도해주세요`);
     }
   } finally {
     LoadingState.value = false;  // 로딩 종료
@@ -50,17 +156,17 @@ const handleRegisterSubmit = async (formData) => {
 <template>
   <div class="register-view">
     <div v-if="LoadingState" class="loading-spinner">잠시만 기다려 주세요...</div>
-    <RegisterForm v-else @submit="handleRegisterSubmit" :errorMessage="errorMessage"/>
-    <RouterView />
+    <RegisterForm v-else @submit="handleRegisterSubmit" @email="checkEmail" @confirm="verifyEmailCode"
+                  @nickname="checkDuplicationNickname"
+                  :errorMessage="errorMessage" :sendEmail="sendEmail" :emailVerified="emailVerified"
+                  :duplicationEmail="duplicationEmail" :duplicationNickname="duplicationNickname"/>
   </div>
 </template>
 
 <style scoped>
 .register-view {
-  margin-top: 40px;  /* 폼 위쪽 여백 추가 */
-  margin-bottom: 100px; /* 폼 아래쪽 여백 추가 */
   display: flex;
-  justify-content: center; /* 화면 가운데에 폼을 정렬 */
+  align-items: center;
 }
 
 .loading-spinner {


### PR DESCRIPTION

## 📝 PR 설명
로그인 회원가입 구현 완료

### 📌 관련 이슈
- **해결할 이슈**: Closes #(이슈 번호)
> 위와 같이 `Closes`, `Fixes`, `Resolves` 키워드를 사용하여 PR이 병합되면 자동으로 해당 이슈가 닫히도록 설정할 수 있습니다.

### 변경 사항
- **핵심 변경 내용**: 로그인 뷰, 회원가입 뷰 구현, 시큐리티파일 일부 수정,
- **주요 변경 파일 및 모듈**: 

### 🔍 상세 설명
- **구현 내용**: 로그인 폼을 이용해 로그인 시 토큰과 시퀀스, 이메일 정보 이용 가능

### 📋 테스트 사항
- **테스트 추가 여부**: 회원가입과 로그인 형식에 맞춰 진행 -> 테이블에 올라감 -> auth.js에 토큰 정보들 잘 저장됨

### 🖥️ 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/7aa229e9-b363-4e20-93ff-9c78f1852228)
![image](https://github.com/user-attachments/assets/6de33d95-bbba-4517-a29b-5ce57b339dcb)

