### PR TITLE
fix: 유저 상세 조회에서 파일 정보가 없는 유저가 검색되지 않는 문제 left join으로 해결

### DIFF
--- a/backend/src/main/java/com/dwbh/backend/repository/user/CustomUserRepository.java
+++ b/backend/src/main/java/com/dwbh/backend/repository/user/CustomUserRepository.java
@@ -28,8 +28,8 @@ public class CustomUserRepository {
                         user.userGender,
                         user.userTemperature))
                 .from(user)
-                .join(userProfileFile).on(user.userSeq.eq(userProfileFile.userSeq))
-                .join(file).on(userProfileFile.fileSeq.eq(file.fileSeq))
+                .leftJoin(userProfileFile).on(user.userSeq.eq(userProfileFile.userSeq))
+                .leftJoin(file).on(userProfileFile.fileSeq.eq(file.fileSeq))
                 .where(user.userSeq.eq(userSeq))
                 .fetchOne();
     }


### PR DESCRIPTION
## 📝 PR 설명
유저 상세 조회에서 파일 정보가 없는 유저가 검색되지 않는 문제 left join으로 해결

### 📌 관련 이슈
- **해결할 이슈**: Closes #123 

### 변경 사항
- **핵심 변경 내용**: 유저 상세 조회 querydsl leftjoin으로 변경

### ✅ 체크리스트
- [x] 코드가 컴파일/빌드 됨
- [ ] 테스트가 통과함 (단위 테스트 및 통합 테스트 포함)
- [ ] 문서가 업데이트됨 (필요시)